### PR TITLE
Update model classes for other model families

### DIFF
--- a/os_expr/run_ft_accelerator.py
+++ b/os_expr/run_ft_accelerator.py
@@ -24,7 +24,7 @@ from model import Model, DecoderClassifier
 cpu_cont = multiprocessing.cpu_count()
 from transformers import (WEIGHTS_NAME, AdamW, get_linear_schedule_with_warmup,
                           LlamaConfig, LlamaModel, LlamaTokenizer,
-                          Starcoder2Config, Starcoder2Model, AutoTokenizer,
+                          Starcoder2Config, Starcoder2Model, AutoTokenizer, AutoModel, AutoConfig,
                           )
 
 from accelerate import Accelerator
@@ -661,7 +661,8 @@ def main():
 
         logger.info("reload model from {}, resume from {} epoch".format(checkpoint_last, args.start_epoch))
 
-    config_class, model_class, tokenizer_class = MODEL_CLASSES[args.model_type]
+    config_class, model_class, tokenizer_class = MODEL_CLASSES.get(args.model_type, (AutoConfig, AutoModel, AutoTokenizer))
+
     config = config_class.from_pretrained(args.config_name if args.config_name else args.model_name_or_path,
                                           cache_dir=args.cache_dir if args.cache_dir else None)
     


### PR DESCRIPTION
Hi again,

Just a recommendation but I think there should be default model configs, classes and tokenizers, so that the script could be extended to other types of model families.

This will also become more convenient when someone wants to recreate the benchmark with CodeBert, UniXCoder.

Thank you all again!